### PR TITLE
Multiple yml fixes

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - "electrum_ps_datadir:/srv"
     environment:
-      - HOST = 'bitcoind_container_name'
+      - HOST = 'bitcoind'
       - PORT = '43782'
       - RPC_USER = 'eps'
       - RPC_PASSWORD = 'cmhKyeLSco35KVhecK3blYcHFx73xrJ1fOQtjtmiKks'

--- a/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 50002:50002
     volumes:
-      - "electrum_ps_datadir:/data"
+      - "electrum_ps_datadir:/srv"
     environment:
       - DAEMON_URL=eps:cmhKyeLSco35KVhecK3blYcHFx73xrJ1fOQtjtmiKks=@bitcoind:43782
 volumes:

--- a/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-electrum-ps.yml
@@ -12,7 +12,11 @@ services:
     volumes:
       - "electrum_ps_datadir:/srv"
     environment:
-      - DAEMON_URL=eps:cmhKyeLSco35KVhecK3blYcHFx73xrJ1fOQtjtmiKks=@bitcoind:43782
+      - HOST = 'bitcoind_container_name'
+      - PORT = '43782'
+      - RPC_USER = 'eps'
+      - RPC_PASSWORD = 'cmhKyeLSco35KVhecK3blYcHFx73xrJ1fOQtjtmiKks'
+      - XPUB = 'xpub_blah_blah'
 volumes:
   electrum_ps_datadir:
 incompatible:


### PR DESCRIPTION
Self explanatory for the persistent volume directory - should work now. 

Is there a reason this has DAEMON_URL as a monolithic var? EPS config.ini takes bitcoind credentials discretely - would be easier for the container to have the vars passed individually than write a script to parse one big var.

Do we want to pass the xpub in an environment variable also? Otherwise the container will need to be a) started to create the volume b) stopped c) config.ini edited and d) container restarted. 

